### PR TITLE
Fix regex compatibility issue across browsers

### DIFF
--- a/frontend/src/search-results/SearchResultsPage.tsx
+++ b/frontend/src/search-results/SearchResultsPage.tsx
@@ -48,9 +48,10 @@ export const SearchResultsPage = (props: Props): ReactElement<Props> => {
   const sortDispatch = sortContextValue.dispatch;
 
   const searchString = props.location?.search;
-  const regex = /(?<=\?q=).*?(?=&|$)/;
+  const regex = /\?q=([^&]*)/;
+  const matches = searchString?.match(regex);
+  const searchQuery = matches ? decodeURIComponent(matches[1]) : null;
 
-  const searchQuery = `${searchString?.match(regex)}`;
 
   usePageTitle(pageTitle);
 


### PR DESCRIPTION
Replace the regex lookbehind in SearchResultsPage with a compatible pattern to ensure the application functions correctly on all browsers, including older versions of Safari and Firefox. This change prevents the app from rendering a blank page due to unsupported regex features.

The updated regex captures the query parameter without using lookbehind assertions, thus improving compatibility and stability.

- Old regex: /(?<=\?q=).*?(?=&|$)/
- New regex: /\?q=([^&]*)/