### PR TITLE
Optimize LCP by Preloading Banner Image in HomeBanner Component

### DIFF
--- a/frontend/src/components/HomeBanner.tsx
+++ b/frontend/src/components/HomeBanner.tsx
@@ -6,12 +6,16 @@ interface HomeBannerProps {
   subheading?: string;
   image?: ImageProps;
   buttonCopy?: string;
+  preload?: boolean;
 }
 
-export const HomeBanner = ({ heading, subheading, image, buttonCopy }: HomeBannerProps) => {
+export const HomeBanner = ({ heading, subheading, image, buttonCopy, preload }: HomeBannerProps) => {
   return (
     <section className="homeBanner">
       <div className="container">
+        {preload && image && (
+            <link rel="preload" as="image" href={image.url} /> // Preload the image
+        )}
         <div className="copy">
           <h1>{heading}</h1>
           {subheading && <p>{subheading}</p>}

--- a/frontend/src/landing-page/LandingPage.tsx
+++ b/frontend/src/landing-page/LandingPage.tsx
@@ -59,6 +59,7 @@ export const LandingPage = (props: Props): ReactElement => {
               buttonCopy={pageData.bannerButtonCopy}
               image={pageData.bannerImage}
               subheading={pageData.bannerMessage}
+              preload
             />
             {pageData.introBlocks && <IntroBlocks {...pageData.introBlocks} />}
             <div className="container" id="homeContent">


### PR DESCRIPTION
#### Overview
This PR aims to optimize the Largest Contentful Paint (LCP) on the landing page by preloading the banner image in the `HomeBanner` component. This enhancement ensures faster loading times for the critical banner image, improving the overall user experience.

#### Changes Made
- **HomeBanner Component:**
  - Added a `preload` prop to the `HomeBanner` component to enable preloading of the banner image.
  - Included a `<link rel="preload" as="image" href={image.url} />` tag within the `HomeBanner` component to preload the banner image when the `preload` prop is true.

- **LandingPage Component:**
  - Updated the `LandingPage` component to pass the `preload` prop to the `HomeBanner` component, ensuring the banner image is preloaded.

#### Benefits
- **Improved Performance:** Preloading the banner image reduces the time it takes for the largest contentful paint, leading to a faster and smoother initial page load.
- **Enhanced User Experience:** Users will experience quicker access to the main content, resulting in a better first impression and improved engagement.

#### Before and After
- **Before:** The banner image would load with the rest of the content, potentially delaying the rendering of the largest contentful paint.
- **After:** The banner image is preloaded, ensuring it is ready to display as soon as possible, improving the LCP metric.

#### Testing
- Verified that the `preload` prop effectively preloads the banner image.
- Tested the `HomeBanner` and `LandingPage` components to ensure they function correctly with the new changes.
- Ensured no regressions in the display or behavior of the banner and other components.

#### Related Issues
- Addresses performance optimization related to LCP on the landing page.

Please review the changes and provide feedback. Your approval will help in enhancing the performance and user experience of our landing page.

---

### Screenshots
If applicable, include before and after screenshots to visually demonstrate the performance improvements.

Thank you for your time and consideration in reviewing this PR!