### PR TITLE
Fix for NJWE-2344: Properly Encode Search Query to Handle Special Characters

### DIFF
--- a/frontend/src/ApiClient.ts
+++ b/frontend/src/ApiClient.ts
@@ -14,7 +14,8 @@ import {
 
 export class ApiClient implements Client {
   getTrainingsByQuery(query: string, observer: Observer<TrainingResult[]>): void {
-    this.get(`/api/trainings/search?query=${query}`, observer);
+    const encodedQuery = encodeURIComponent(query);
+    this.get(`/api/trainings/search?query=${encodedQuery}`, observer);
   }
 
   getTrainingById(id: string, observer: Observer<Training>): void {


### PR DESCRIPTION
This PR addresses the issue described in [NJWE-2344](https://fearless.jira.com/browse/NJWE-2344?atlOrigin=eyJpIjoiOTFhZjk1MTQ4ZmJkNGYwZjg1NWZjMjFlNjFhMjc5YWIiLCJwIjoiaiJ9), where search queries containing special characters, such as &, were being truncated when processed by the back end. The issue was traced to the query string not being URL-encoded before it was sent in the API request.

Changes:

    Updated the getTrainingsByQuery method in ApiClient.ts to use encodeURIComponent on the search query string before appending it to the URL. This ensures that special characters are properly encoded and that the full query is processed by the server.

Testing:

    Verified that search queries containing special characters, including &, are now correctly processed and return the expected results.
    Checked for regressions by running searches with queries that do not contain special characters.

JIRA Ticket:
[NJWE-2344](https://fearless.jira.com/browse/NJWE-2344?atlOrigin=eyJpIjoiOTFhZjk1MTQ4ZmJkNGYwZjg1NWZjMjFlNjFhMjc5YWIiLCJwIjoiaiJ9)