### PR TITLE
fix(training): handle missing CE records gracefully

### DIFF
--- a/backend/src/domain/training/findTrainingsBy.test.ts
+++ b/backend/src/domain/training/findTrainingsBy.test.ts
@@ -39,4 +39,14 @@ describe.skip('findTrainingsByFactory', () => {
     const trainings = await findTrainingsBy(1, ['a', 'b']);
     expect(trainings).toEqual(expectedResult);
   });
+
+  it("should return an empty array when no CE records are found", async () => {
+    const stubDataClient = StubDataClient();
+    const findTrainingsBy = findTrainingsByFactory(stubDataClient);
+
+    const trainings = await findTrainingsBy(1, ["nonexistentValue"]);
+
+    expect(trainings).toEqual([]);
+  });
+
 });

--- a/backend/src/domain/training/findTrainingsBy.ts
+++ b/backend/src/domain/training/findTrainingsBy.ts
@@ -37,8 +37,7 @@ export const findTrainingsByFactory = (dataClient: DataClient): FindTrainingsBy 
     const ceRecords = await credentialEngineUtils.fetchValidCEData(values);
 
     if (ceRecords.length === 0) {
-      console.error("404 Not found: No CE Records Found");
-      throw new Error("Not Found");
+      return [];
     }
 
     // Process each CTDL resource record asynchronously


### PR DESCRIPTION
- Updated `findTrainingsBy.ts` to return an empty array instead of throwing an error when no CE records are found.
- Added a test case in `findTrainingsBy.test.ts` to verify this behavior.
- Ensured the function fails gracefully and does not produce unhandled errors in logs.

Resolves NJWE-2639.